### PR TITLE
Update email_renamer.py - use Pathlibinstead of os, replace list comprehension with glob.glob

### DIFF
--- a/scripts/email_renamer.py
+++ b/scripts/email_renamer.py
@@ -1,8 +1,8 @@
 from dateutil.parser import parse
-import os
 import glob
 import extract_msg
 import hashlib
+from pathlib import Path
 
 """Prepends the received datetime of an msg email file as a string to the .msg file name
 Delimited by a #
@@ -16,7 +16,6 @@ my_log_file = "log.txt"
 ### set to filepath of folder containing .msg files to process.
 folder = r"folder"
 
-
 def md5(fname):
     hash_md5 = hashlib.md5()
     with open(fname, "rb") as f:
@@ -24,29 +23,31 @@ def md5(fname):
             hash_md5.update(chunk)
     return hash_md5.hexdigest()
 
-
 log_data = []
-for f in [x for x in os.listdir(folder) if x.endswith(".msg")]:
-	msg_filepath = os.path.join(folder, f)
 
-	msg_glob = glob.glob(msg_filepath)
+msg_files = glob.glob(folder+'/*.msg')
 
-	for filename in msg_glob:
-		msg = extract_msg.Message(filename)
-		msg_sender = msg.sender
-		msg_date = msg.date
-		msg_subject = msg.subject
-		msg_body = msg.body
-		msg_datetime = parse(msg_date)
-		msg_date_string = msg_datetime.strftime("%Y_%m_%d-%H_%M_%S")
-		new_filename = msg_date_string+"#"+f
-		new_filepath = os.path.join(folder, new_filename)
-		msg.close()
+for msg_file in msg_files:
+    msg_file_md5 = md5(msg_file)
 
-	msg_file_md5 = md5(msg_file)
-	os.rename(msg_filepath,new_filepath)
-	log_data.append(f"{msg_filepath}|{new_filename}|{msg_file_md5}")
+    msg = extract_msg.Message(msg_file)
+    msg_sender = msg.sender
+    msg_subject = msg.subject
+    msg_body = msg.body
+    msg_date = msg.date
+    msg.close()
+
+    msg_datetime = parse(msg_date)
+    msg_date_string = msg_datetime.strftime("%Y_%m_%d-%H_%M_%S")
+
+    msg_filepath = Path(msg_file)
+    msg_filename = msg_filepath.name
+    new_filename = msg_date_string+"#"+msg_filename
+    new_filepath = Path(folder).joinpath(new_filename)
+    msg_filepath.rename(new_filepath)
+
+    log_data.append(f"{msg_filepath}|{new_filename}|{msg_file_md5}")
 
 with open(my_log_file, "w", encoding = "utf8") as data:
-	data.write("\n".join(log_data))
+    data.write("\n".join(log_data))
 


### PR DESCRIPTION
More substantive changes - replaces os library with Pathlib, and switches the list comprehension previously at line 29 with glob.glob, instead of finding the .msg files first and passing them one at a time to glob.glob. If this is not a better way I'm happy to be ignored.